### PR TITLE
Fix noscript link to use HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
         <br />            
         For functionality of this site it is necessary to enable JavaScript. 
 		<br />  
-		Here are the <a href="http://www.enable-javascript.com/" target="_blank">instructions how to enable JavaScript in your web browser</a>.
+                Here are the <a href="https://www.enable-javascript.com/" target="_blank">instructions how to enable JavaScript in your web browser</a>.
 		</span>
     </noscript>
 	


### PR DESCRIPTION
## Summary
- fix the enable-JavaScript link in `index.html` to use HTTPS

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6845128083fc832bafe550cb7b64ee6a