### PR TITLE
Use multiplication sign for operator display

### DIFF
--- a/scripts/site.js
+++ b/scripts/site.js
@@ -191,7 +191,7 @@ function GetProblem() {
 	var topNum = Math.floor((Math.random() * 13)); // 0 to 12
 	var bottomNum = Math.floor((Math.random() * 13)); // 0 to 12
 	$('#topNumber').text(topNum); 
-	$('#operator').text('X');
+        $('#operator').text('×');
 	$('#bottomNumber').text(bottomNum); 
 	$('#guess').val('');
 	$('#message').hide();


### PR DESCRIPTION
## Summary
- display the proper multiplication symbol when showing the operator

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845128236d0832b81f811c0ef445563